### PR TITLE
cx_Freeze package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,5 +7,5 @@ environment:
 build_script:
   - cmd: package.bat
 artifacts:
-- path: build\exe.win32-3.6\Wangcheck.zip
+- path: build\Wangcheck.zip
   name: Wangcheck executable package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+version: 1.0.{build}
+branches:
+  only:
+  - master
+environment:
+  PYTHON: C:\Python36
+build_script:
+  - cmd: package.bat
+artifacts:
+- path: build\exe.win32-3.6\Wangcheck.zip
+  name: Wangcheck executable package

--- a/package.bat
+++ b/package.bat
@@ -1,0 +1,13 @@
+echo Please ensure PYTHON is set to the directory of Python installation at version 3.6.
+set OLD_PATH=%PATH%
+PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+python --version
+pip --version
+pip install cx_Freeze
+pip install -r requirements.txt
+python setup.py build_exe
+cd build
+move exe.win32-3.6 Wangcheck
+7z a Wangcheck.zip Wangcheck
+cd ..
+PATH=%OLD_PATH%

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema>=2.6.0

--- a/setup.py
+++ b/setup.py
@@ -1,167 +1,30 @@
-#!/usr/bin/python3
-# -*- coding: utf-8 -*-
-# Created by: python.exe -m py2exe Wangcheck.py -W setup.py
+import sys
+from cx_Freeze import setup, Executable
 
-from distutils.core import setup
-import py2exe
+# Dependencies are automatically detected, but it might need fine tuning.
+excludes = [
+  "_ssl",
+  "unicodedata",
+  "pyexpat",
+  "_hashlib",
+  "_bz2",
+  "html",
+  "logging",
+  "pydoc_data",
+  "unittest",
+  "xml"
+]
+build_exe_options = {
+    "packages": [],
+    "excludes": excludes,
+    "optimize": 2}
 
-class Target(object):
-    '''Target is the baseclass for all executables that are created.
-    It defines properties that are shared by all of them.
-    '''
-    def __init__(self, **kw):
-        self.__dict__.update(kw)
+# GUI applications require a different base on Windows (the default is for a
+# console application).
+base = None
 
-        # the VersionInfo resource, uncomment and fill in those items
-        # that make sense:
-        
-        # The 'version' attribute MUST be defined, otherwise no versioninfo will be built:
-        # self.version = "1.0"
-        
-        # self.company_name = "Company Name"
-        # self.copyright = "Copyright Company Name © 2013"
-        # self.legal_copyright = "Copyright Company Name © 2013"
-        # self.legal_trademark = ""
-        # self.product_version = "1.0.0.0"
-        # self.product_name = "Product Name"
-
-        # self.private_build = "foo"
-        # self.special_build = "bar"
-
-    def copy(self):
-        return Target(**self.__dict__)
-
-    def __setitem__(self, name, value):
-        self.__dict__[name] = value
-
-RT_BITMAP = 2
-RT_MANIFEST = 24
-
-# A manifest which specifies the executionlevel
-# and windows common-controls library version 6
-
-manifest_template = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <assemblyIdentity
-    version="5.0.0.0"
-    processorArchitecture="*"
-    name="%(prog)s"
-    type="win32"
-  />
-  <description>%(prog)s</description>
-  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-    <security>
-      <requestedPrivileges>
-        <requestedExecutionLevel
-            level="%(level)s"
-            uiAccess="false">
-        </requestedExecutionLevel>
-      </requestedPrivileges>
-    </security>
-  </trustInfo>
-  <dependency>
-    <dependentAssembly>
-        <assemblyIdentity
-            type="win32"
-            name="Microsoft.Windows.Common-Controls"
-            version="6.0.0.0"
-            processorArchitecture="*"
-            publicKeyToken="6595b64144ccf1df"
-            language="*"
-        />
-    </dependentAssembly>
-  </dependency>
-</assembly>
-'''
-
-
-
-Wangcheck = Target(
-    # We can extend or override the VersionInfo of the base class:
-    # version = "1.0",
-    # file_description = "File Description",
-    # comments = "Some Comments",
-    # internal_name = "spam",
-
-    script="Wangcheck.py", # path of the main script
-
-    # Allows to specify the basename of the executable, if different from 'Wangcheck'
-    # dest_base = "Wangcheck",
-
-    # Icon resources:[(resource_id, path to .ico file), ...]
-    # icon_resources=[(1, r"Wangcheck.ico")]
-
-    other_resources = [(RT_MANIFEST, 1, (manifest_template % dict(prog="Wangcheck", level="asInvoker")).encode("utf-8")),
-    # for bitmap resources, the first 14 bytes must be skipped when reading the file:
-    #                    (RT_BITMAP, 1, open("bitmap.bmp", "rb").read()[14:]),
-                      ]
-    )
-
-
-# ``zipfile`` and ``bundle_files`` options explained:
-# ===================================================
-#
-# zipfile is the Python runtime library for your exe/dll-files; it
-# contains in a ziparchive the modules needed as compiled bytecode.
-#
-# If 'zipfile=None' is used, the runtime library is appended to the
-# exe/dll-files (which will then grow quite large), otherwise the
-# zipfile option should be set to a pathname relative to the exe/dll
-# files, and a library-file shared by all executables will be created.
-#
-# The py2exe runtime *can* use extension module by directly importing
-# the from a zip-archive - without the need to unpack them to the file
-# system.  The bundle_files option specifies where the extension modules,
-# the python dll itself, and other needed dlls are put.
-#
-# bundle_files == 3:
-#     Extension modules, the Python dll and other needed dlls are
-#     copied into the directory where the zipfile or the exe/dll files
-#     are created, and loaded in the normal way.
-#
-# bundle_files == 2:
-#     Extension modules are put into the library ziparchive and loaded
-#     from it directly.
-#     The Python dll and any other needed dlls are copied into the
-#     directory where the zipfile or the exe/dll files are created,
-#     and loaded in the normal way.
-#
-# bundle_files == 1:
-#     Extension modules and the Python dll are put into the zipfile or
-#     the exe/dll files, and everything is loaded without unpacking to
-#     the file system.  This does not work for some dlls, so use with
-#     caution.
-#
-# bundle_files == 0:
-#     Extension modules, the Python dll, and other needed dlls are put
-#     into the zipfile or the exe/dll files, and everything is loaded
-#     without unpacking to the file system.  This does not work for
-#     some dlls, so use with caution.
-
-
-py2exe_options = dict(
-    packages = [],
-##    excludes = "tof_specials Tkinter".split(),
-##    ignores = "dotblas gnosis.xml.pickle.parsers._cexpat mx.DateTime".split(),
-##    dll_excludes = "MSVCP90.dll mswsock.dll powrprof.dll".split(),
-    optimize=0,
-    compressed=False, # uncompressed may or may not have a faster startup
-    bundle_files=3,
-    dist_dir='dist',
-    )
-
-
-# Some options can be overridden by command line options...
-
-setup(name="name",
-      # console based executables
-      console=[Wangcheck],
-
-      # windows subsystem executables (no console)
-      windows=[],
-
-      # py2exe options
-      zipfile=None,
-      options={"py2exe": py2exe_options},
-      )
-
+setup(  name = "Wangcheck",
+        version = "0.1",
+        description = "Validate JSON configuration files for Wangscape",
+        options = {"build_exe": build_exe_options},
+        executables = [Executable("Wangcheck.py", base=base)])

--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,4 @@ setup(  name = "Wangcheck",
         version = "0.1",
         description = "Validate JSON configuration files for Wangscape",
         options = {"build_exe": build_exe_options},
-        executables = [Executable("Wangcheck.py", base=base)])
+        executables = [Executable("wangcheck.py", base=base)])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,167 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+# Created by: python.exe -m py2exe wangcheck.py -W setup.py
+
+from distutils.core import setup
+import py2exe
+
+class Target(object):
+    '''Target is the baseclass for all executables that are created.
+    It defines properties that are shared by all of them.
+    '''
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+        # the VersionInfo resource, uncomment and fill in those items
+        # that make sense:
+        
+        # The 'version' attribute MUST be defined, otherwise no versioninfo will be built:
+        # self.version = "1.0"
+        
+        # self.company_name = "Company Name"
+        # self.copyright = "Copyright Company Name © 2013"
+        # self.legal_copyright = "Copyright Company Name © 2013"
+        # self.legal_trademark = ""
+        # self.product_version = "1.0.0.0"
+        # self.product_name = "Product Name"
+
+        # self.private_build = "foo"
+        # self.special_build = "bar"
+
+    def copy(self):
+        return Target(**self.__dict__)
+
+    def __setitem__(self, name, value):
+        self.__dict__[name] = value
+
+RT_BITMAP = 2
+RT_MANIFEST = 24
+
+# A manifest which specifies the executionlevel
+# and windows common-controls library version 6
+
+manifest_template = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    version="5.0.0.0"
+    processorArchitecture="*"
+    name="%(prog)s"
+    type="win32"
+  />
+  <description>%(prog)s</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel
+            level="%(level)s"
+            uiAccess="false">
+        </requestedExecutionLevel>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <dependency>
+    <dependentAssembly>
+        <assemblyIdentity
+            type="win32"
+            name="Microsoft.Windows.Common-Controls"
+            version="6.0.0.0"
+            processorArchitecture="*"
+            publicKeyToken="6595b64144ccf1df"
+            language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+</assembly>
+'''
+
+
+
+wangcheck = Target(
+    # We can extend or override the VersionInfo of the base class:
+    # version = "1.0",
+    # file_description = "File Description",
+    # comments = "Some Comments",
+    # internal_name = "spam",
+
+    script="wangcheck.py", # path of the main script
+
+    # Allows to specify the basename of the executable, if different from 'wangcheck'
+    # dest_base = "wangcheck",
+
+    # Icon resources:[(resource_id, path to .ico file), ...]
+    # icon_resources=[(1, r"wangcheck.ico")]
+
+    other_resources = [(RT_MANIFEST, 1, (manifest_template % dict(prog="wangcheck", level="asInvoker")).encode("utf-8")),
+    # for bitmap resources, the first 14 bytes must be skipped when reading the file:
+    #                    (RT_BITMAP, 1, open("bitmap.bmp", "rb").read()[14:]),
+                      ]
+    )
+
+
+# ``zipfile`` and ``bundle_files`` options explained:
+# ===================================================
+#
+# zipfile is the Python runtime library for your exe/dll-files; it
+# contains in a ziparchive the modules needed as compiled bytecode.
+#
+# If 'zipfile=None' is used, the runtime library is appended to the
+# exe/dll-files (which will then grow quite large), otherwise the
+# zipfile option should be set to a pathname relative to the exe/dll
+# files, and a library-file shared by all executables will be created.
+#
+# The py2exe runtime *can* use extension module by directly importing
+# the from a zip-archive - without the need to unpack them to the file
+# system.  The bundle_files option specifies where the extension modules,
+# the python dll itself, and other needed dlls are put.
+#
+# bundle_files == 3:
+#     Extension modules, the Python dll and other needed dlls are
+#     copied into the directory where the zipfile or the exe/dll files
+#     are created, and loaded in the normal way.
+#
+# bundle_files == 2:
+#     Extension modules are put into the library ziparchive and loaded
+#     from it directly.
+#     The Python dll and any other needed dlls are copied into the
+#     directory where the zipfile or the exe/dll files are created,
+#     and loaded in the normal way.
+#
+# bundle_files == 1:
+#     Extension modules and the Python dll are put into the zipfile or
+#     the exe/dll files, and everything is loaded without unpacking to
+#     the file system.  This does not work for some dlls, so use with
+#     caution.
+#
+# bundle_files == 0:
+#     Extension modules, the Python dll, and other needed dlls are put
+#     into the zipfile or the exe/dll files, and everything is loaded
+#     without unpacking to the file system.  This does not work for
+#     some dlls, so use with caution.
+
+
+py2exe_options = dict(
+    packages = [],
+##    excludes = "tof_specials Tkinter".split(),
+##    ignores = "dotblas gnosis.xml.pickle.parsers._cexpat mx.DateTime".split(),
+##    dll_excludes = "MSVCP90.dll mswsock.dll powrprof.dll".split(),
+    optimize=0,
+    compressed=False, # uncompressed may or may not have a faster startup
+    bundle_files=3,
+    dist_dir='dist',
+    )
+
+
+# Some options can be overridden by command line options...
+
+setup(name="name",
+      # console based executables
+      console=[wangcheck],
+
+      # windows subsystem executables (no console)
+      windows=[],
+
+      # py2exe options
+      zipfile=None,
+      options={"py2exe": py2exe_options},
+      )
+

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
-# Created by: python.exe -m py2exe wangcheck.py -W setup.py
+# Created by: python.exe -m py2exe Wangcheck.py -W setup.py
 
 from distutils.core import setup
 import py2exe
@@ -76,22 +76,22 @@ manifest_template = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
 
 
-wangcheck = Target(
+Wangcheck = Target(
     # We can extend or override the VersionInfo of the base class:
     # version = "1.0",
     # file_description = "File Description",
     # comments = "Some Comments",
     # internal_name = "spam",
 
-    script="wangcheck.py", # path of the main script
+    script="Wangcheck.py", # path of the main script
 
-    # Allows to specify the basename of the executable, if different from 'wangcheck'
-    # dest_base = "wangcheck",
+    # Allows to specify the basename of the executable, if different from 'Wangcheck'
+    # dest_base = "Wangcheck",
 
     # Icon resources:[(resource_id, path to .ico file), ...]
-    # icon_resources=[(1, r"wangcheck.ico")]
+    # icon_resources=[(1, r"Wangcheck.ico")]
 
-    other_resources = [(RT_MANIFEST, 1, (manifest_template % dict(prog="wangcheck", level="asInvoker")).encode("utf-8")),
+    other_resources = [(RT_MANIFEST, 1, (manifest_template % dict(prog="Wangcheck", level="asInvoker")).encode("utf-8")),
     # for bitmap resources, the first 14 bytes must be skipped when reading the file:
     #                    (RT_BITMAP, 1, open("bitmap.bmp", "rb").read()[14:]),
                       ]
@@ -155,7 +155,7 @@ py2exe_options = dict(
 
 setup(name="name",
       # console based executables
-      console=[wangcheck],
+      console=[Wangcheck],
 
       # windows subsystem executables (no console)
       windows=[],

--- a/wangcheck.py
+++ b/wangcheck.py
@@ -104,12 +104,15 @@ class Wangcheck(object):
     self.check_images()
     self.load_metaoutput()
     self.check_metaoutput()
+def print_usage():
+  print("Usage: python wangcheck.py path/to/options.json path/to/Wangscape/doc/schemas")
 
 if __name__ == '__main__':
   try:
     _, options_path, schema_dir = sys.argv
   except ValueError:
-    print("Usage: python wangcheck.py path/to/options.json path/to/Wangscape/doc/schemas")
+    print_usage()
+    raise
   config_dir, options_fn = path.split(options_path)
   wc = Wangcheck(config_dir, options_fn, schema_dir)
   wc.check_all()

--- a/wangcheck.py
+++ b/wangcheck.py
@@ -1,0 +1,78 @@
+from jsonschema import validate, Draft4Validator, ValidationError
+from json import load, JSONDecodeError
+from os import path
+import sys
+
+class Wangcheck(object):
+  def __init__(self, config_dir, options_fn, schema_dir):
+    self.config_dir = config_dir
+    self.options_fn = options_fn
+    self.schema_dir = schema_dir
+  def config_file_path(self, filename):
+    return path.join(self.config_dir, filename)
+  def schema_file_path(self, filename):
+    return path.join(self.schema_dir, filename)
+  def loadf(self, fn):
+    with open(fn) as f:
+      return load(f)
+  def load_schemas(self):
+    self.schema_options = self.loadf(self.schema_file_path('options_schema.json'))
+    self.schema_module_group = self.loadf(self.schema_file_path('module_group_schema.json'))
+  def load_options(self):
+    self.options = self.loadf(self.config_file_path(self.options_fn))
+  def load_module_groups(self):
+    self.combiner_module_group = self.loadf(self.config_file_path(self.options['CombinerModuleGroup']))
+    self.source_modules = {}
+    if 'DefaultModuleGroup' in self.options:
+      mg_default = self.options['DefaultModuleGroup']
+      self.source_modules[mg_default] = self.loadf(self.config_file_path(mg_default))
+    for mg_type in [
+      'TopBorderModuleGroups',
+      'LeftBorderModuleGroups',
+      'CentralBorderModuleGroups']:
+      if mg_type not in self.options:
+        continue
+      for mg in self.options[mg_type]:
+        mg_fn = mg['Filename']
+        if mg_fn not in self.source_modules:
+          try:
+            self.source_modules[mg_fn] = self.loadf(self.config_file_path(mg_fn))
+          except JSONDecodeError:
+            print("Error in {0}:\n".format(mg_fn))
+            raise
+  def check_schemas(self):
+    Draft4Validator.check_schema(self.schema_options)
+    Draft4Validator.check_schema(self.schema_module_group)
+  def check_options(self):
+    validate(self.options, self.schema_options)
+  def check_module_groups(self):
+    validate(self.combiner_module_group, self.schema_module_group)
+    if 'inputmodules' not in self.combiner_module_group:
+      print("Warning: combiner module group requires three input modules")
+    for fn, mg in self.source_modules.items():
+      try:
+        validate(mg, self.schema_module_group)
+      except ValidationError:
+        print('Error in {0}:\n'.format(fn))
+        raise
+  def check_images(self):
+    for terrain in self.options['Terrains'].values():
+      filename = terrain['FileName']
+      assert path.exists(self.config_file_path(filename)),"Image not found: {0}\n".format(filename)
+  def check_all(self):
+    self.load_schemas()
+    self.check_schemas()
+    self.load_options()
+    self.check_options()
+    self.load_module_groups()
+    self.check_module_groups()
+    self.check_images()
+
+if __name__ == '__main__':
+  try:
+    _, options_path, schema_dir = sys.argv
+  except ValueError:
+    print("Usage: python wangcheck.py path/to/options.json path/to/Wangscape/doc/schemas")
+  config_dir, options_fn = path.split(options_path)
+  wc = Wangcheck(config_dir, options_fn, schema_dir)
+  wc.check_all()


### PR DESCRIPTION
Resolves #4. Required to resolve https://github.com/Wangscape/Wangscape/issues/122.

Uses cx_Freeze because py2exe can't handle data files in Python packages.

Branched from #2.